### PR TITLE
Support for Jade include directives

### DIFF
--- a/lib/mincer/engines/jade_engine.js
+++ b/lib/mincer/engines/jade_engine.js
@@ -27,6 +27,7 @@
 
 
 // 3rd-party
+var path = require('path');
 var _ = require('underscore');
 var Jade;   // initialized later
 
@@ -86,9 +87,10 @@ JadeEngine.setOptions = function (value) {
 // Render data
 JadeEngine.prototype.evaluate = function (context, locals, callback) {
   try {
+    var jade_path = path.resolve(context.rootPath, context.pathname);
     var result = Jade.compile(this.data, _.extend({}, options, {
       client:   true,
-      filename: context.logicalPath
+      filename: jade_path
     }));
 
     callback(null, result.toString());


### PR DESCRIPTION
Hi,
I've committed a very minor change to enable the use of Jade `include` directives (useful for mixins, for example). Jade starts from the passed `filename` to resolve the file to include, and it requires an absolute pathname, so it's just a matter of passing the full pathname instead of the logical one.

Cheers,
Marco
