### PR TITLE
More generic helpers support (needed for example for some Stylus helpers)

### DIFF
--- a/lib/mincer/context.js
+++ b/lib/mincer/context.js
@@ -72,8 +72,8 @@ var Context = module.exports = function Context(environment, logicalPath, pathna
 // See Context.registerHelper()
 prop(Context.prototype, '__helpers__', {
   // note we'll need to backpatch `func` later
-  asset_data_uri:   {name: 'asset_data_uri', func: Context.prototype.assetDataUri, opts: {kind: 'generic'}},
-  asset_path:       {name: 'asset_path', func: Context.prototype.assetPath, opts: {kind: 'generic'}}
+  asset_data_uri:   {name: 'asset_data_uri', func: Context.prototype.assetDataUri},
+  asset_path:       {name: 'asset_path', func: Context.prototype.assetPath}
 });
 
 
@@ -151,18 +151,17 @@ Context.prototype.__helpers__['asset_path'].func = Context.prototype.assetPath;
  *  Exposed to the engines as `stylesheet_path` helper.
  **/
 
-['image', 'video', 'audio', 'font', 'javascript', 'stylesheet'].forEach(function (type) {
+['image', 'video', 'audio', 'font', 'javascript', 'stylesheet'].forEach(function (assetType) {
   var func = function (pathname) {
-    return this.assetPath(pathname, {type: type});
+    return this.assetPath(pathname, {type: assetType});
   };
-  //Context.registerHelper(type + '_path', func);
+  //Context.registerHelper(assetType + '_path', func);
   var helper = {
-    name: type + '_path',
-    func: func,
-    opts: { kind: 'generic' }
+    name: assetType + '_path',
+    func: func
   };
-  Context.prototype.__helpers__[type + '_path'] = helper;
-  Context.prototype[type + 'Path'] = func;
+  Context.prototype.__helpers__[assetType + '_path'] = helper;
+  Context.prototype[assetType + 'Path'] = func;
 });
 
 
@@ -208,6 +207,16 @@ getter(Context.prototype, 'logicalPath', function () {
  **/
 getter(Context.prototype, 'contentType', function () {
   return this.environment.contentTypeOf(this.pathname);
+});
+
+
+/**
+ *  Context#context -> Object
+ *
+ *  Returns the context itself
+ **/
+getter(Context.prototype, 'context', function () {
+  return this;
 });
 
 
@@ -411,14 +420,14 @@ Context.prototype.evaluate = function (pathname, options, callback) {
               : fs.readFileSync(pathname, 'utf8');
 
   _.each(this.__helpers__, function (helper, name) {
-    if (helper.opts.kind == 'stylus') {
+    var opts = helper.opts || {};
+    if (opts.type == 'stylus') {
       // for stylus helpers, the context is the one passed by stylus
       locals[name] = helper.func;  // no wrapper here: stylus helpers need the stylus context
     } else {
       // for other helpers, the context is this Context itself
-      var func = helper.func;      // avoid clouse capturing wrong value
       locals[name] = function () {
-        return func.apply(self, arguments);
+        return helper.func.apply(self, arguments);
       };
     }
   });
@@ -456,12 +465,10 @@ function define_helpers_registrator(Klass) {
   Klass.registerHelper = function (name, func, opts) {
     // Scenario: registerHelper('foo', foo_helper);
     // Scenario: registerHelper('foo', foo_helper, foo_opts);
-    opts = opts || {};
-    _.defaults(opts, {kind: 'generic'});
     var helper = {
       name: name,
       func: func,
-      opts: opts
+      opts: opts || {}
     };
     if (_.isString(name)) {
       Klass.prototype[name]             = func;

--- a/lib/mincer/engines/stylus_engine.js
+++ b/lib/mincer/engines/stylus_engine.js
@@ -115,6 +115,9 @@ StylusEngine.prototype.evaluate = function (context, locals, callback) {
         o[k] = (this[i] || {}).val;
       }, arguments);
 
+      if (this && (!'context' in this)) {
+        this.context = context;
+      }
       return func.call(this, o.a, o.b, o.c, o.d, o.e, o.f, o.g, o.h);
     });
   });


### PR DESCRIPTION
Hi,
I've added a slightly more generic mechanism for helpers, which allows to distinguish between different kinds of helpers. This is needed for example for Stylus, where helpers need the context in effect when stylus invoked the helper (and not the mincer Context instance, which would be the default).
The mechanism is backward compatible, the API for helper registration is the same, only adding an _optional_ parameter `options`, where it's possible to specify a `kind` field.
For example, I needed this to integrate naltatis/node-sprite sprite stylus helper with minces.
