### PR TITLE
support for stylus-sprite

### DIFF
--- a/lib/mincer/engines/stylus_engine.js
+++ b/lib/mincer/engines/stylus_engine.js
@@ -23,6 +23,7 @@ var path = require('path');
 // 3rd-party
 var _ = require('underscore');
 var stylus; // initialized later
+var sprite;
 
 
 // internal
@@ -52,6 +53,17 @@ StylusEngine.prototype.isInitialized = function () {
 // Autoload stylus library
 StylusEngine.prototype.initializeEngine = function () {
   stylus = this.require('stylus');
+  try {
+    // autoload optional stylus plugin
+    var StylusSprite = this.require('stylus-sprite');
+    sprite = new StylusSprite({output_file:"app/assets/images/sprite.png"});
+  } catch(e) {
+    if (/Cannot find module/.test(e) === true) {
+      sprite = false; // safe to carry on without it
+    } else {
+      throw(e);
+    }
+  }
 };
 
 
@@ -123,6 +135,12 @@ StylusEngine.prototype.evaluate = function (context, locals, callback) {
     });
   });
 
+  if (sprite) {
+    style.define('sprite', function (f, o) {
+      return sprite.spritefunc(f, o);
+    });
+  }
+
   // run registered configurators
   _.each(configurators, function (fn) {
     fn(style);
@@ -134,17 +152,28 @@ StylusEngine.prototype.evaluate = function (context, locals, callback) {
       return;
     }
 
-    try {
-      // add Stylus `@import`s as dependencies of current asset
-      _.each(style.options._imports, function (imported) {
-        context.dependOn(imported.path);
-      });
-    } catch (err) {
-      callback(err, css);
-      return;
-    }
+    var f = function anonymous(css) {
+      try {
+        // add Stylus `@import`s as dependencies of current asset
+        _.each(style.options._imports, function (imported) {
+          context.dependOn(imported.path);
+        });
+      } catch (err) {
+        callback(err, css);
+        return;
+      }
 
-    callback(null, css);
+      callback(null, css);
+    };
+    if (sprite) {
+      sprite.build(css, function(err, css) {
+        if (err) throw err;
+        f(css);
+      });
+    }
+    else {
+      f(css);
+    }
   });
 };
 


### PR DESCRIPTION
optional; if lib is present. 

TODO: should probably provide a sprite output path that is not hard-coded. 
TODO: also it would be nice to support outputting multiple sprite files instead of just one (e.g. include output name as an option to 'sprite' stylus helper).

see also: https://github.com/andris9/stylus-sprite
and my fork which contains a couple patches to make it work for node v0.6.12:
https://github.com/mikesmullin/stylus-sprite
