### PR TITLE
Support JavaScript Templating with EJS

### DIFF
--- a/lib/mincer/engines/ejs_engine.js
+++ b/lib/mincer/engines/ejs_engine.js
@@ -29,6 +29,9 @@ var Template = require('../template');
 
 // Class constructor
 var EjsEngine = module.exports = function EjsEngine() {
+  if(arguments[0].match(/jst.ejs/)){
+    this.isJST = true;
+  }
   Template.apply(this, arguments);
 };
 
@@ -51,7 +54,13 @@ EjsEngine.prototype.initializeEngine = function () {
 // Render data
 EjsEngine.prototype.evaluate = function (context, locals, callback) {
   try {
-    callback(null, ejs.render(this.data, {scope: context, locals: locals}));
+    if(this.isJST){
+      var source = ejs.parse(this.data,{compileDebug: false});
+      source = "function(locals){" + source + "}";
+      callback(null,source);
+    }else{
+      callback(null, ejs.render(this.data, {scope: context, locals: locals}));
+    }
   } catch (err) {
     callback(err);
   }


### PR DESCRIPTION
My rails project use JST using EJS.
Because Sprockets supports jst of EJS. 
I want to raplace the rails project with Node.js.
So,I want to support JST using ejs.

This patch modifies below

if asset path includes "jst.ejs" ,  ejs engine returns the string parseing  and envolving
function otherwise the same as before.
