### PR TITLE
Add the filename to ejs for `include` directive

### DIFF
--- a/lib/mincer/engines/ejs_engine.js
+++ b/lib/mincer/engines/ejs_engine.js
@@ -51,7 +51,7 @@ EjsEngine.prototype.initializeEngine = function () {
 // Render data
 EjsEngine.prototype.evaluate = function (context, locals, callback) {
   try {
-    callback(null, ejs.render(this.data, {scope: context, locals: locals}));
+    callback(null, ejs.render(this.data, {scope: context, locals: locals, filename: context.pathname}));
   } catch (err) {
     callback(err);
   }


### PR DESCRIPTION
EJS has a newer [`include`](https://github.com/visionmedia/ejs#includes) directive to replace the old `partial` function in express. This just includes a file relative to the current. The engine has to know the path of the template in order for this to happen.
