### PR TITLE
Expose third party preprocessors

### DIFF
--- a/lib/mincer/engines/coffee_engine.js
+++ b/lib/mincer/engines/coffee_engine.js
@@ -18,7 +18,6 @@
 
 // 3rd-party
 var _ = require('underscore');
-var coffee; // initialized later
 
 
 // internal
@@ -30,9 +29,14 @@ var prop      = require('../common').prop;
 
 
 // Class constructor
-var CoffeeEngine = module.exports = function CoffeeEngine() {
+var CoffeeEngine = module.exports = exports = function CoffeeEngine() {
   Template.apply(this, arguments);
 };
+
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 
 require('util').inherits(CoffeeEngine, Template);
@@ -40,13 +44,13 @@ require('util').inherits(CoffeeEngine, Template);
 
 // Check whenever coffee-script module is loaded
 CoffeeEngine.prototype.isInitialized = function () {
-  return !!coffee;
+  return !!exports._engine;
 };
 
 
 // Autoload coffee-script library
 CoffeeEngine.prototype.initializeEngine = function () {
-  coffee = this.require('coffee-script');
+  exports._engine = this.require('coffee-script');
 };
 
 
@@ -73,7 +77,7 @@ CoffeeEngine.setOptions = function (value) {
 // Render data
 CoffeeEngine.prototype.evaluate = function (context, locals, callback) {
   try {
-    var result = coffee.compile(this.data, _.clone(options));
+    var result = exports._engine.compile(this.data, _.clone(options));
     callback(null, result);
   } catch (err) {
     callback(err);

--- a/lib/mincer/engines/ejs_engine.js
+++ b/lib/mincer/engines/ejs_engine.js
@@ -16,10 +16,6 @@
 'use strict';
 
 
-// 3rd-party
-var ejs; // initialized later
-
-
 // internal
 var Template = require('../template');
 
@@ -28,9 +24,14 @@ var Template = require('../template');
 
 
 // Class constructor
-var EjsEngine = module.exports = function EjsEngine() {
+var EjsEngine = module.exports = exports = function EjsEngine() {
   Template.apply(this, arguments);
 };
+
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 
 require('util').inherits(EjsEngine, Template);
@@ -38,20 +39,20 @@ require('util').inherits(EjsEngine, Template);
 
 // Check whenever ejs module is loaded
 EjsEngine.prototype.isInitialized = function () {
-  return !!ejs;
+  return !!exports._engine;
 };
 
 
 // Autoload ejs library
 EjsEngine.prototype.initializeEngine = function () {
-  ejs = this.require('ejs');
+  exports._engine = this.require('ejs');
 };
 
 
 // Render data
 EjsEngine.prototype.evaluate = function (context, locals, callback) {
   try {
-    callback(null, ejs.render(this.data, {scope: context, locals: locals, filename: context.pathname}));
+    callback(null, exports._engine.render(this.data, {scope: context, locals: locals}));
   } catch (err) {
     callback(err);
   }

--- a/lib/mincer/engines/haml_coffee_engine.js
+++ b/lib/mincer/engines/haml_coffee_engine.js
@@ -21,37 +21,40 @@
 
 // 3rd-party
 var _ = require('underscore');
-var CoffeeScript; // initialized later
-var HamlCoffee;   // initialized later
 
 
 // internal
-var Template  = require('../template');
-var prop      = require('../common').prop;
+var Template       = require('../template');
+var prop           = require('../common').prop;
+var coffee_engine  = require('./coffee_engine');
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
 
 // Class constructor
-var HamlCoffeeEngine = module.exports = function HamlCoffeeEngine() {
+var HamlCoffeeEngine = module.exports = exports = function HamlCoffeeEngine() {
   Template.apply(this, arguments);
 };
 
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 require('util').inherits(HamlCoffeeEngine, Template);
 
 
 // Check whenever coffee-script module is loaded
 HamlCoffeeEngine.prototype.isInitialized = function () {
-  return !!CoffeeScript && !!HamlCoffee;
+  return !!coffee_engine._engine && !!exports._engine;
 };
 
 
 // Autoload coffee-script library
 HamlCoffeeEngine.prototype.initializeEngine = function () {
-  CoffeeScript  = this.require('coffee-script');
-  HamlCoffee    = this.require('haml-coffee/src/haml-coffee');
+  coffee_engine._engine  = this.require('coffee-script');
+  exports._engine = this.require('haml-coffee/src/haml-coffee');
 };
 
 
@@ -83,7 +86,7 @@ HamlCoffeeEngine.prototype.evaluate = function (context, locals, callback) {
   var compiler, source;
 
   try {
-    compiler = new HamlCoffee(_.clone(options));
+    compiler = new exports._engine(_.clone(options));
 
     compiler.parse(this.data);
 
@@ -91,7 +94,7 @@ HamlCoffeeEngine.prototype.evaluate = function (context, locals, callback) {
              compiler.precompile().replace(/^(.*)$/mg, '  $1') +
              ').call(params)';
 
-    callback(null, CoffeeScript.compile(source, {bare: true}));
+    callback(null, coffee_engine._engine.compile(source, {bare: true}));
   } catch (err) {
     callback(err);
   }

--- a/lib/mincer/engines/jade_engine.js
+++ b/lib/mincer/engines/jade_engine.js
@@ -28,7 +28,6 @@
 
 // 3rd-party
 var _ = require('underscore');
-var Jade;   // initialized later
 
 
 // internal
@@ -40,23 +39,28 @@ var prop      = require('../common').prop;
 
 
 // Class constructor
-var JadeEngine = module.exports = function JadeEngine() {
+var JadeEngine = module.exports = exports = function JadeEngine() {
   Template.apply(this, arguments);
 };
+
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 
 require('util').inherits(JadeEngine, Template);
 
 
-// Check whenever coffee-script module is loaded
+// Check whenever jade module is loaded
 JadeEngine.prototype.isInitialized = function () {
-  return !!Jade;
+  return !!exports._engine;
 };
 
 
-// Autoload coffee-script library
+// Autoload jade library
 JadeEngine.prototype.initializeEngine = function () {
-  Jade = this.require('jade');
+  exports._engine = this.require('jade');
 };
 
 
@@ -86,7 +90,7 @@ JadeEngine.setOptions = function (value) {
 // Render data
 JadeEngine.prototype.evaluate = function (context, locals, callback) {
   try {
-    var result = Jade.compile(this.data, _.extend({}, options, {
+    var result = exports._engine.compile(this.data, _.extend({}, options, {
       client:   true,
       filename: context.pathname
     }));

--- a/lib/mincer/engines/less_engine.js
+++ b/lib/mincer/engines/less_engine.js
@@ -22,7 +22,6 @@ var path = require('path');
 
 // 3rd-party
 var _ = require('underscore');
-var less; // initialized later
 
 
 // internal
@@ -34,9 +33,14 @@ var prop      = require('../common').prop;
 
 
 // Class constructor
-var LessEngine = module.exports = function LessEngine() {
+var LessEngine = module.exports = exports = function LessEngine() {
   Template.apply(this, arguments);
 };
+
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 
 require('util').inherits(LessEngine, Template);
@@ -44,13 +48,13 @@ require('util').inherits(LessEngine, Template);
 
 // Check whenever less module is loaded
 LessEngine.prototype.isInitialized = function () {
-  return !!less;
+  return !!exports._engine;
 };
 
 
 // Autoload less library
 LessEngine.prototype.initializeEngine = function () {
-  less = this.require('less');
+  exports._engine = this.require('less');
 };
 
 
@@ -92,7 +96,7 @@ function less_error(ctx, options) {
 // Render data
 LessEngine.prototype.evaluate = function (context, locals, callback) {
   var self   = this;
-  var parser = new (less.Parser)({
+  var parser = new (exports._engine.Parser)({
     paths:          [path.dirname(this.file)].concat(context.environment.paths),
     optimization:   1,
     filename:       this.file,

--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -17,7 +17,6 @@
 
 
 // 3rd-party
-var sass; // initialized later
 
 
 // internal
@@ -29,9 +28,14 @@ var prop      = require('../common').prop;
 
 
 // Class constructor
-var SassEngine = module.exports = function SassEngine() {
+var SassEngine = module.exports = exports = function SassEngine() {
   Template.apply(this, arguments);
 };
+
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 
 require('util').inherits(SassEngine, Template);
@@ -39,19 +43,19 @@ require('util').inherits(SassEngine, Template);
 
 // Check whenever node-sass module is loaded
 SassEngine.prototype.isInitialized = function () {
-  return !!sass;
+  return !!exports._engine;
 };
 
 
 // Autoload node-sass library
 SassEngine.prototype.initializeEngine = function () {
-  sass = this.require('node-sass');
+  exports._engine = this.require('node-sass');
 };
 
 
 // Render data
 SassEngine.prototype.evaluate = function (context, locals, callback) {
-  sass.render(this.data, callback);
+  exports._engine.render(this.data, callback);
 };
 
 

--- a/lib/mincer/engines/stylus_engine.js
+++ b/lib/mincer/engines/stylus_engine.js
@@ -22,7 +22,6 @@ var path = require('path');
 
 // 3rd-party
 var _ = require('underscore');
-var stylus; // initialized later
 
 
 // internal
@@ -35,9 +34,14 @@ var getter    = require('../common').getter;
 
 
 // Class constructor
-var StylusEngine = module.exports = function StylusEngine() {
+var StylusEngine = module.exports = exports = function StylusEngine() {
   Template.apply(this, arguments);
 };
+
+/*
+ * Expose engine
+ */
+exports._engine = null; // initialized later
 
 
 require('util').inherits(StylusEngine, Template);
@@ -45,13 +49,13 @@ require('util').inherits(StylusEngine, Template);
 
 // Check whenever stylus is loaded
 StylusEngine.prototype.isInitialized = function () {
-  return !!stylus;
+  return !!exports._engine;
 };
 
 
 // Autoload stylus library
 StylusEngine.prototype.initializeEngine = function () {
-  stylus = this.require('stylus');
+  exports._engine = this.require('stylus');
 };
 
 
@@ -98,7 +102,7 @@ getter(StylusEngine, 'configurators', function () {
 
 // Render data
 StylusEngine.prototype.evaluate = function (context, locals, callback) {
-  var style = stylus(this.data, {
+  var style = exports._engine(this.data, {
     paths:    [path.dirname(this.file)].concat(context.environment.paths),
     filename: this.file,
     _imports: []


### PR DESCRIPTION
This will allow devs to give an engine the preprocessor object instead
of mincer looking it up.

This is a follow up to #61
