### PR TITLE
Solving errors with travis

### DIFF
--- a/lib/mincer/asset_attributes.js
+++ b/lib/mincer/asset_attributes.js
@@ -22,6 +22,7 @@ var _ = require('underscore');
 // internal
 var prop    = require('./common').prop;
 var getter  = require('./common').getter;
+var pathsep = require('./common').pathsep;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,7 +52,7 @@ getter(AssetAttributes.prototype, 'searchPaths', function () {
   }, this.pathname);
 
   // optimization: component.json can only be nested one level deep
-  if (-1 === path_without_extensions.indexOf(path.sep)) {
+  if (-1 === path_without_extensions.indexOf(pathsep)) {
     paths.push(path.join(path_without_extensions, "component.json"));
   }
 
@@ -90,7 +91,7 @@ getter(AssetAttributes.prototype, 'logicalPath', function () {
                     paths.join(", "));
   }
 
-  pathname = pathname.replace(root_path + path.sep, "");
+  pathname = pathname.replace(root_path + pathsep, "");
   pathname = this.engineExtensions.reduce(function (p, ext) {
     return p.replace(ext, "");
   }, pathname);

--- a/lib/mincer/common.js
+++ b/lib/mincer/common.js
@@ -45,11 +45,18 @@ module.exports.normalizeExtension = function (extension) {
 };
 
 
+// nodejs 0.6 workarround for path.sep
+var pathsep = path.sep;
+if (!pathsep) {
+  pathsep = path.resolve('.')[0] === '/' ? '/' : '\\';
+}
+module.exports.pathsep = pathsep;
+
 
 // Dummy alternative to Ruby's Pathname#is_absolute
-/*var ABSOLUTE_PATH_PATTERN = (path.sep === '/' ? /^\// : /:/);*/
+/*var ABSOLUTE_PATH_PATTERN = (pathsep === '/' ? /^\// : /:/);*/
 module.exports.isAbsolute = function (pathname) {
-  return /*unix*/ (path.sep === '/' && '/' === pathname[0]) || (/*win*/ pathname.indexOf(':') >= 0);
+  return /*unix*/ (pathsep === '/' && '/' === pathname[0]) || (/*win*/ pathname.indexOf(':') >= 0);
 };
 
 

--- a/lib/mincer/engines/jst_engine.js
+++ b/lib/mincer/engines/jst_engine.js
@@ -96,6 +96,7 @@ var path  = require('path');
 // internal
 var Template  = require('../template');
 var prop      = require('../common').prop;
+var pathsep   = require('../common').pathsep;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -148,9 +149,9 @@ JstEngine.prototype.evaluate = function (context, locals, callback) {
 
   // JST members should have "unix path separators"
   oldLogicalPath = '';
-  while (path.sep !== '/' && oldLogicalPath !== logicalPath) {
+  while (pathsep !== '/' && oldLogicalPath !== logicalPath) {
     oldLogicalPath = logicalPath;
-    logicalPath    = logicalPath.replace(path.sep, '/');
+    logicalPath    = logicalPath.replace(pathsep, '/');
   }
 
   callback(


### PR DESCRIPTION
Travis was pointing errors with version 0.6 of node.js.
The reason of this is that node 0.6 does not define the `sep` property to `path` object.
