### PR TITLE
Add missing module 'node-sass' for dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
                         "ejs"           : "*",
                         "eco"           : "*",
                         "coffee-script" : "*",
+                        "node-sass"     : "*",
                         "haml-coffee"   : "*",
                         "jade"          : "*",
                         "less"          : "*",


### PR DESCRIPTION
`Mincer.SassEngine` requires `node-sass`.
