### PR TITLE
Switch from `cut` to `sed`, to be compatible with BSD based systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TMP_PATH    := /tmp/${NPM_PACKAGE}-$(shell date +%s)
 REMOTE_NAME ?= origin
 REMOTE_REPO ?= $(shell git config --get remote.${REMOTE_NAME}.url)
 
-CURR_HEAD   := $(firstword $(shell git show-ref --hash HEAD | cut --bytes=-6) master)
+CURR_HEAD   := $(firstword $(shell git show-ref --hash HEAD | sed 's/^\(.\{6\}\).*$$/\1/') master)
 GITHUB_PROJ := nodeca/${NPM_PACKAGE}
 
 


### PR DESCRIPTION
`--bytes` doesn't work with BSD version of cut.

Related: https://github.com/cosmin/git-hg/issues/9
