### PR TITLE
Add support for Coco, a CoffeeScript dialect.

### DIFF
--- a/lib/mincer.js
+++ b/lib/mincer.js
@@ -100,6 +100,11 @@ Mincer.StylusEngine       = require('./mincer/engines/stylus_engine');
  **/
 Mincer.CoffeeEngine       = require('./mincer/engines/coffee_engine');
 
+/**
+ *  Mincer.CocoEngine -> CocoEngine
+ **/
+Mincer.CocoEngine       = require('./mincer/engines/coco_engine');
+
 
 /**
  *  Mincer.SassEngine -> SassEngine
@@ -228,6 +233,7 @@ Mincer.registerBundleProcessor('text/css',              Mincer.CharsetNormalizer
 // Register JS engines
 Mincer.registerEngine('.coffee',    Mincer.CoffeeEngine);
 Mincer.registerEngine('.litcoffee', Mincer.CoffeeEngine);
+Mincer.registerEngine('.co',        Mincer.CocoEngine);
 
 
 // JST engines

--- a/lib/mincer/engines/coco_engine.js
+++ b/lib/mincer/engines/coco_engine.js
@@ -1,0 +1,91 @@
+/**
+ *  class CocoEngine
+ *
+ *  Engine for the Coco compiler. You will need `coco` Node
+ *  module installed in order to use [[Mincer]] with `*.co` files:
+ *
+ *      npm install coco
+ *
+ *
+ *  ##### SUBCLASS OF
+ *
+ *  [[Template]]
+ **/
+
+
+'use strict';
+
+// 3rd-party
+var _ = require('underscore');
+var coco; // initialized later
+
+
+// internal
+var Template  = require('../template');
+var prop      = require('../common').prop;
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Class constructor
+var CocoEngine = module.exports = function CocoEngine() {
+  Template.apply(this, arguments);
+};
+
+
+require('util').inherits(CocoEngine, Template);
+
+
+// Check whenever coco module is loaded
+CocoEngine.prototype.isInitialized = function () {
+  return !!coco;
+};
+
+
+// Autoload coco library
+CocoEngine.prototype.initializeEngine = function () {
+  coco = this.require('coco');
+};
+
+
+// Internal (private) options storage
+var options = {bare: true};
+
+
+/**
+ *  CocoEngine.setOptions(value) -> Void
+ *  - value (Object):
+ *
+ *  Allows to set Coco compilation options.
+ *  Default: `{bare: true}`.
+ *
+ *  ##### Example
+ *
+ *      CocoEngine.setOptions({bare: true});
+ **/
+CocoEngine.setOptions = function (value) {
+  options = _.clone(value);
+};
+
+
+// Render data
+CocoEngine.prototype.evaluate = function (context, locals, callback) {
+  /*jshint unused:false*/
+  try {
+    var result, compilerOptions;
+
+    compilerOptions = _.extend({}, options, {
+    });
+
+    result = coco.compile(this.data, compilerOptions);
+
+    callback(null, result);
+  } catch (err) {
+    callback(err);
+  }
+};
+
+
+// Expose default MimeType of an engine
+prop(CocoEngine, 'defaultMimeType', 'application/javascript');


### PR DESCRIPTION
I copied and modified CoffeeEngine files to make CocoEngine. I couldn't
find any unit tests for engines, so I didn't add one, but I did test it
manually and it seemed to work.
