### PR TITLE
Convert `source` to a String

### DIFF
--- a/lib/mincer/assets/processed.js
+++ b/lib/mincer/assets/processed.js
@@ -229,6 +229,8 @@ ProcessedAsset.prototype.compile = function (callback) {
       callback(err);
       return;
     }
+    
+    source = _.isString(source) ? source : source.toString();
 
     // save rendered string
     prop(self, '__buffer__', new Buffer(source));


### PR DESCRIPTION
Address issue #86 - make sure the `source` evaluation result is a String.
