### PR TITLE
Output correct logicalPath on Windows

### DIFF
--- a/lib/mincer/asset_attributes.js
+++ b/lib/mincer/asset_attributes.js
@@ -91,6 +91,7 @@ getter(AssetAttributes.prototype, 'logicalPath', function () {
   }
 
   pathname = pathname.replace(root_path + path.sep, "");
+  pathname = pathname.replace(/\\/g, '/');
   pathname = this.engineExtensions.reduce(function (p, ext) {
     return p.replace(ext, "");
   }, pathname);


### PR DESCRIPTION
When running on Windows the asset's `logicalPath` may contain backslashes.
Replace backslashes with slashes to make sure we have a valid `logicalPath`.

(Please ignore the "Revert "Convert `source` to a String"" commit in this one - I got a little mixed up with things and it isn't relevant to this commit.)
