### PR TITLE
Add *_url helpers to context. This is required because e.g. less parse u...

### DIFF
--- a/lib/mincer/context.js
+++ b/lib/mincer/context.js
@@ -150,6 +150,9 @@ Context.prototype.assetPath = function assetPath() {
   Context.prototype[assetType + 'Path'] = function (pathname) {
     return this.assetPath(pathname, {type: assetType});
   };
+  Context.prototype[assetType + 'Url'] = function(pathname) {
+    return "url('" + this.assetPath(pathname, {type: assetType}) + "')";
+  };
 });
 
 
@@ -501,15 +504,13 @@ define_helpers_registrator(Context);
 // Register all standard (built-in) helpers
 Context.registerHelper({
   'asset_data_uri':   Context.prototype.assetDataUri,
-  'asset_path':       Context.prototype.assetPath,
-  'image_path':       Context.prototype.imagePath,
-  'video_path':       Context.prototype.videoPath,
-  'audio_path':       Context.prototype.audioPath,
-  'font_path':        Context.prototype.fontPath,
-  'javascript_path':  Context.prototype.javascriptPath,
-  'stylesheet_path':  Context.prototype.stylesheetPath
+  'asset_path':       Context.prototype.assetPath
 });
 
+['image', 'video', 'audio', 'font', 'javascript', 'stylesheet'].forEach(function(assetType) {
+  Context.registerHelper(assetType + '_path', Context.prototype[assetType + 'Path']);
+  Context.registerHelper(assetType + '_url', Context.prototype[assetType + 'Url']);
+});
 
 /**
  *  Context.defineAssetPath(func) -> Void


### PR DESCRIPTION
...rl directives separately and could not evaluate functions inside.
