### PR TITLE
Added toString at jst_engine data evaluate

### DIFF
--- a/lib/mincer/engines/jst_engine.js
+++ b/lib/mincer/engines/jst_engine.js
@@ -58,7 +58,7 @@ JstEngine.prototype.evaluate = function (context/*, locals*/) {
   return "(function () { " +
     namespace + " || (" + namespace + " = {}); " +
     namespace + "[" + JSON.stringify(context.logicalPath) + "] = " +
-    this.data.replace(/$(.)/mg, '$1  ').trimLeft().trimRight() +
+    this.data.toString().replace(/$(.)/mg, '$1  ').trimLeft().trimRight() +
     " }).call(this);";
 };
 


### PR DESCRIPTION
When you try to compile some assets with `*.eco`, occurs the error that replace method cannot be found for `this.data` object at jst_engine `evaluate` function.
It happens because at line 61 the `this.data` object isn't a string yet. So I attached `toString()` to it and the error stopped to happen, compiles with success all files, including `.eco` files.
It's only a change at line 61 to compile `.eco` files with success.
