### PR TITLE
Revert "Simplify circular call protection"

### DIFF
--- a/lib/mincer/base.js
+++ b/lib/mincer/base.js
@@ -501,24 +501,34 @@ var circular_calls = null;
 
 
 function circular_call_protection(pathname, callback) {
-  var reset = (null === circular_calls),
-      calls = circular_calls || (circular_calls = []);
+  var reset   = (null === circular_calls),
+      calls   = circular_calls || (circular_calls = []),
+      result  = null,
+      error   = null;
+
+  if (0 <= calls.indexOf(pathname)) {
+    if (reset) { circular_calls = null; }
+    throw new Error("Circular dependency detected: " + pathname +
+                    " has already been required");
+  }
+
+  calls.push(pathname);
 
   try {
-    if (0 <= calls.indexOf(pathname)) {
-      throw new Error("Circular dependency detected: " + pathname +
-                      " has already been required");
-    }
-
-    calls.push(pathname);
-    return callback();
+    result = callback();
   } catch (err) {
-    if (reset) {
-      circular_calls = null;
-    }
-
-    throw err;
+    error = err;
   }
+
+  if (reset) {
+    circular_calls = null;
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  return result;
 }
 
 


### PR DESCRIPTION
This reverts commit 4ad0ebe6d20165a81384da5edc8ca1e8eb3a3710.

Due to changes in this commit, circular_calls list is reset only when
callback fails, which leads to a spurious 'has already been required'
error on subsequent attempts to compile an asset.
