### PR TITLE
Keep empty lines in the header.

### DIFF
--- a/lib/mincer/processors/directive_processor.js
+++ b/lib/mincer/processors/directive_processor.js
@@ -323,7 +323,7 @@ DirectiveProcessor.prototype.processSource = function () {
   // if our own body was not yet appended, and there are header comments,
   // prepend these coments first.
   if (!self.__hasWrittenBody__ && 0 < self.processedHeader.length) {
-    self.result += self.processedHeader + "\n";
+    self.result += self.processedHeader;
   }
 
   // process and append body of each path that should be included
@@ -356,8 +356,8 @@ getter(DirectiveProcessor.prototype, 'processedHeader', function () {
 
   if (!this.__processedHeader__) {
     header = get_lines(this.header).map(function (line, index) {
-      return is_directive(this.directives, index + 1) ? "\n" : line;
-    }, this).join("\n").trimLeft().trimRight();
+      return is_directive(this.directives, index + 1) ? "" : line;
+    }, this).join("\n");
 
     prop(this, '__processedHeader__', header);
   }


### PR DESCRIPTION
This change increases accuracy of error messages for files with
directives in them.
