### PR TITLE
Make Processor#evaluate synchronous.

### DIFF
--- a/lib/mincer/context.js
+++ b/lib/mincer/context.js
@@ -437,7 +437,7 @@ Context.prototype.evaluate = function (pathname, options) {
 
     try {
       template  = new ProcessorKlass(pathname, result, processors[idx + 1]);
-      result    = template.evaluate(self);
+      result    = template.evaluate(self, locals);
     } catch (err) {
       throw self.annotateError(err, ProcessorKlass);
     }


### PR DESCRIPTION
When the API was made synchronous in 65ab72530300d2c3bcf13971e54bb887b3c6fdf1, it seems there was an oversight in making Processor#evaluate synchronous. Making this synchronous fixes #110.
