### PR TITLE
Fix for jade API changes

### DIFF
--- a/lib/mincer/engines/jade_engine.js
+++ b/lib/mincer/engines/jade_engine.js
@@ -75,9 +75,23 @@ JadeEngine.configure = function (opts) {
 // Render data
 JadeEngine.prototype.evaluate = function (context, locals) {
   if (this.nextProcessor && "JstEngine" === this.nextProcessor.name) {
-    return Jade.compileClient(this.data, _.extend({}, options, {
+    var result,
+        opts;
+
+    opts = _.extend({}, options, {
+      client: true,
       filename: context.logicalpath
-    })).toString();
+    });
+
+    if (typeof Jade.compileClient === "function") {
+      // jade >= 1.0.0
+      result = Jade.compileClient(this.data, opts);
+    } else {
+      // jade <= 0.35
+      result = Jade.compile(this.data, opts);
+    }
+
+    return result.toString();
   }
 
   return Jade.render(this.data, _.extend({}, options, locals, {


### PR DESCRIPTION
Since jade changed it's API (visionmedia/jade#1298) it throws an error when using client templates:

```
Error: The `client` option is deprecated, use `jade.compileClient`
```
