### PR TITLE
Fixed SourceMap length for multibyte characters

### DIFF
--- a/lib/mincer/server.js
+++ b/lib/mincer/server.js
@@ -196,7 +196,7 @@ function serve_smap(self, asset, req, res, timer) {
     self.log('info', log_event(req, 200, 'OK', timer.stop()));
 
     res.setHeader('Content-Type', 'application/json');
-    res.setHeader('Content-Length', asset.sourceMap.length);
+    res.setHeader('Content-Length', Buffer.byteLength(asset.sourceMap));
 
     res.statusCode = 200;
 


### PR DESCRIPTION
When a source map contains multibyte characters, incorrect Content-Length is set.
It happened for me when sending a source map with inlined sources of underscore.js.
