### PR TITLE
Added source maps support for concatenated assets

### DIFF
--- a/lib/mincer/assets/bundled.js
+++ b/lib/mincer/assets/bundled.js
@@ -16,6 +16,8 @@
 
 // 3rd-party
 var _ = require('lodash');
+var convertSourceMap = require('convert-source-map');
+var combineSourceMap = require('combine-source-map');
 
 
 // internal
@@ -33,7 +35,8 @@ var Asset   = require('./asset');
  *  See [[Asset.new]] for details.
  **/
 var BundledAsset = module.exports = function BundledAsset() {
-  var processedAsset, Klass, context, processors, options, source = '';
+  var processedAsset, Klass, context, processors, options,
+      source = '', sourceMap, sourceMapOffset;
 
   Asset.apply(this, arguments);
   prop(this, 'type', 'bundled');
@@ -44,15 +47,35 @@ var BundledAsset = module.exports = function BundledAsset() {
   prop(this, '__requiredAssets__',  processedAsset.__requiredAssets__);
   prop(this, '__dependencyPaths__', processedAsset.__dependencyPaths__);
 
+  // concat source and combine source maps
+  sourceMap = combineSourceMap.create(this.logicalPath, '');
+  sourceMapOffset = { line: 0 };
+
   this.toArray().forEach(function (dep) {
-    source += dep.toString();
+    var depSource, depLines;
+
+    depSource = dep.toString();
+    depLines = depSource.split('\n').length;
+
+    // add source
+    source += depSource;
+
+    // add source map
+    if (dep.sourceMap) {
+      depSource += convertSourceMap.fromJSON(dep.sourceMap).toComment();
+    }
+    sourceMap.addFile({ sourceFile: dep.pathname, source: depSource }, sourceMapOffset);
+    sourceMapOffset.line += depLines;
   });
+  this.sourceMap = convertSourceMap.fromBase64(sourceMap.base64()).toJSON();
 
   // prepare to build ourself
   Klass       = this.environment.ContextClass;
   context     = new Klass(this.environment, this.logicalPath, this.pathname);
   processors  = this.environment.getBundleProcessors(this.contentType);
   options     = { data: source, processors: processors };
+
+  context.sourceMap = this.sourceMap;
 
   this.__source__ = context.evaluate(this.pathname, options);
   this.sourceMap  = context.sourceMap;

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
   "bin"             : { "mincer": "bin/mincer.js" },
   "scripts"         : { "test": "make test" },
   "dependencies"    : {
-                        "argparse"    : "~ 0.1.15",
-                        "async"       : "~ 0.2.9",
-                        "fs-tools"    : "~ 0.2.10",
-                        "hike"        : "~ 0.1.3",
-                        "lodash"      : "~ 2.4.1",
-                        "mimoza"      : "~ 0.3.0",
-                        "shellwords"  : "~ 0.1.0"
+                        "argparse"           : "~ 0.1.15",
+                        "async"              : "~ 0.2.9",
+                        "fs-tools"           : "~ 0.2.10",
+                        "hike"               : "~ 0.1.3",
+                        "lodash"             : "~ 2.4.1",
+                        "mimoza"             : "~ 0.3.0",
+                        "shellwords"         : "~ 0.1.0",
+                        "convert-source-map" : "~ 0.3.3",
+                        "combine-source-map" : "~ 0.3.0"
                       },
   "devDependencies" : {
                         "mocha"         : "*",


### PR DESCRIPTION
I've used [convert-source-map](https://github.com/thlorenz/convert-source-map) and [combine-source-map](https://github.com/thlorenz/combine-source-map) libraries which are also used by browserify.
See [this blog post](http://thlorenz.com/blog/browserify-sourcemaps) on why they've chosen to include the sources (sourcesContent) in the map and keep the map itself as a comment.

The BundledAsset's constructor doesn't seem to be the best place for such strictly source-map-related code, so if you have any suggestions, I'll be glad to fix it.
