### PR TITLE
Error when 'main' inside bower.json is an array

### DIFF
--- a/lib/mincer/base.js
+++ b/lib/mincer/base.js
@@ -219,7 +219,7 @@ Base.prototype.resolve = function (logicalPath, options, fn) {
       }
 
       if (_.isArray(bower.main)) {
-        extname = path.extname(pathname);
+        extname = path.extname(logicalPath);
 
         while (bower.main.length) {
           mainfile = bower.main.shift();


### PR DESCRIPTION
When the 'main' key of a bower.json file, that is an array, is parsed by mincer I have been getting a file not found error. A string works file. Mincer appears to be comparing the file extension of the bower.json file (always .json) against each file listed in the 'main' array. Surely we should be comparing the extension of the logicalPath?

Therefore if we have bower.json file that looks like this:

```
 "main": [
    "./dist/css/bootstrap.css",
    "./dist/js/bootstrap.js",
    "./dist/fonts/glyphicons-halflings-regular.eot",
    "./dist/fonts/glyphicons-halflings-regular.svg",
    "./dist/fonts/glyphicons-halflings-regular.ttf",
    "./dist/fonts/glyphicons-halflings-regular.woff"
  ]
```

And I have the following in my main JS file:

```
//= require bootstrap.js
```

We should compare the extension of the bootstrap.js requested file with each of the 'main' files, where we will match on ./dist/js/bootstrap.js
