### PR TITLE
Add JSX syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ to write CSS assets in Mincer. Use the extension `.css.less`.
 
 ## Styling with SASS
 
-[SASS](http://sass-lang.com/) is an extension of CSS3, adding nested rules, 
+[SASS](http://sass-lang.com/) is an extension of CSS3, adding nested rules,
 variables, mixins, selector inheritance, and more.
 
 If the `node-sass` Node module is available to your application, you can use SASS
@@ -285,6 +285,17 @@ JavaScript code embedded in an asset is evaluated in the context of a
 - embedding other application resources, such as a localized string
   database, in a JavaScript asset via JSON
 - embedding version constants loaded from another file
+
+
+## React.js and JSX syntax
+
+[React.js](http://facebook.github.io/react/) is a JavaScript library for
+building user interfaces embracing functional paradigm. JSX is a syntax
+extension that provides syntactic sugar for writing React components.
+
+If the `react-tools` Node module is available to your application, you can use
+JSX syntax in your JavaScript assets in Mincer.
+Use the extension `.js.jsx`.
 
 
 ## Using helpers

--- a/lib/mincer.js
+++ b/lib/mincer.js
@@ -119,6 +119,12 @@ Mincer.CocoEngine         = require('./mincer/engines/coco_engine');
 
 
 /**
+ *  Mincer.CocoEngine -> CocoEngine
+ **/
+Mincer.JsxEngine         = require('./mincer/engines/jsx_engine');
+
+
+/**
  *  Mincer.SassEngine -> SassEngine
  **/
 Mincer.SassEngine         = require('./mincer/engines/sass_engine');
@@ -279,6 +285,7 @@ Mincer.registerEngine('.ls',        Mincer.LiveScriptEngine);
 Mincer.registerEngine('.coffee',    Mincer.CoffeeEngine);
 Mincer.registerEngine('.litcoffee', Mincer.CoffeeEngine);
 Mincer.registerEngine('.co',        Mincer.CocoEngine);
+Mincer.registerEngine('.jsx',       Mincer.JsxEngine);
 
 
 // Register CSS engines

--- a/lib/mincer/engines/jsx_engine.js
+++ b/lib/mincer/engines/jsx_engine.js
@@ -1,0 +1,47 @@
+/**
+ *  class JsxEngine
+ *
+ *  Engine for the React JSX transformer. You will need `react-tools` Node
+ *  module installed in order to use [[Mincer]] with `*.jsx` files:
+ *
+ *      npm install react-tools
+ *
+ *
+ *  ##### SUBCLASS OF
+ *
+ *  [[Template]]
+ **/
+
+
+'use strict';
+
+
+var jsx; // initialized later
+
+
+// internal
+var Template  = require('../template');
+var prop      = require('../common').prop;
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Class constructor
+var JsxEngine = module.exports = function JsxEngine() {
+  Template.apply(this, arguments);
+  jsx = jsx || Template.libs.jsx || require('react-tools');
+};
+
+
+require('util').inherits(JsxEngine, Template);
+
+
+// Render data
+JsxEngine.prototype.evaluate = function (/*context, locals*/) {
+  return jsx.transform(this.data);
+};
+
+
+// Expose default MimeType of an engine
+prop(JsxEngine, 'defaultMimeType', 'application/javascript');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
                         "ejs"           : "*",
                         "eco"           : "*",
                         "coffee-script" : "*",
+                        "react-tools"   : "*",
                         "LiveScript"    : "*",
                         "haml-coffee"   : "*",
                         "jade"          : "*",

--- a/test/engines_test.js
+++ b/test/engines_test.js
@@ -25,6 +25,13 @@ describe('Engines', function () {
     });
   });
 
+  describe('JSX', function () {
+    it('should transform jsx', function () {
+      var asset = env.findAsset('jsx_engine/javascript');
+      assert(asset.toString().match(/React.DOM.div/));
+    });
+  });
+
   describe('LESS', function () {
     it('should support context helpers', function () {
       var asset = env.findAsset('less_engine/stylesheet');

--- a/test/fixtures/jsx_engine/javascript.js.jsx
+++ b/test/fixtures/jsx_engine/javascript.js.jsx
@@ -1,0 +1,3 @@
+/** @jsx React.DOM */
+
+var el = <div className="test">content</div>;


### PR DESCRIPTION
JSX is a syntactic sugar for writing React.js components. I think it will be cool to have JSXTransform for Mincer.

Tested with `make test`. Created `test.js.jsx` file in a simple express.js app with `connect-assets` that uses my local `mincer` copy, confirmed assets where correctly compiled and line numbers were preserved. Please let me know if I missed something.
