### PR TITLE
Fix a bug of `coffee-engine` if the option to make coffeescript source maps is disabled

### DIFF
--- a/lib/mincer/engines/coffee_engine.js
+++ b/lib/mincer/engines/coffee_engine.js
@@ -83,7 +83,8 @@ CoffeeEngine.prototype.evaluate = function (context/*, locals*/) {
 
   try {
     result = coffee.compile(this.data, compileOpts);
-    this.data = result.js;
+    this.data =
+        context.environment.isEnabled('source_maps') ? result.js : result;
   } catch(err) {
     loc = err.location;
 


### PR DESCRIPTION
If the option to make coffeescript source maps is disabled, Mincer compiles any coffeescript code in an empty javascript code. 
It is because that the coffee engine assign to `context.data` the `js` property of the result of `coffee.compile` which is `String` type if the option is disabled.
