### PR TITLE
Output errors reported by node-sass

### DIFF
--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -19,6 +19,7 @@
 var path = require('path');
 
 // 3rd-party
+var _ = require('lodash');
 var sass; // initialized later
 
 
@@ -45,12 +46,33 @@ var SassEngine = module.exports = function SassEngine() {
 require('util').inherits(SassEngine, Template);
 
 
+// helper to generate human-friendly errors.
+// adapted version from less_engine.js
+function sassError(ctx /*, options*/) {
+  // libsass error string format: path:line: error: message
+  var error = _.zipObject(
+    ['path', 'line', 'level', 'message'],
+    ctx.split(':', 4).map(function(str) { return str.trim(); })
+  );
+  if(error.line && error.level && error.message) {
+    return new Error('Line ' + error.line + ': ' + error.message);
+  }
+
+  return new Error(ctx);
+}
+
+
 // Render data
 SassEngine.prototype.evaluate = function (context/*, locals*/) {
-  this.data = sass.renderSync({
-    data:         this.data,
-    includePaths: [path.dirname(this.file)].concat(context.environment.paths)
-  });
+  try {
+    this.data = sass.renderSync({
+      data:         this.data,
+      includePaths: [path.dirname(this.file)].concat(context.environment.paths)
+    });
+  } catch(err) {
+    var error = sassError(err);
+    throw error;
+  }
 };
 
 


### PR DESCRIPTION
Currently mincer silently ignores errors that occur while compiling Sass files. This pull requests adds parsing of the returned error string into a friendlier format and raises the error.
