### PR TITLE
Iterate over bower.main files instead of choosing the first one only

### DIFF
--- a/lib/mincer/base.js
+++ b/lib/mincer/base.js
@@ -221,9 +221,9 @@ Base.prototype.resolve = function (logicalPath, options, fn) {
       if (_.isArray(bower.main)) {
         extname = path.extname(logicalPath);
 
-        while (bower.main.length) {
-          mainfile = bower.main[0];
-
+        for(var m in bower.main) {
+          mainfile = bower.main[m];
+          
           if ('' === extname || extname === path.extname(mainfile)) {
             return fn(path.join(path.dirname(pathname), mainfile));
           }


### PR DESCRIPTION
This is a really simple change, I modified the loop to use all main files (like in the case of bootstrap) of bower.json.