### PR TITLE
Update SassEngine to handle node-sass 2.x return value.

### DIFF
--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -70,11 +70,7 @@ SassEngine.prototype.evaluate = function (context/*, locals*/) {
       includePaths: [ path.dirname(this.file) ].concat(context.environment.paths),
       indentedSyntax: /^.*\.sass$/.test(this.file)
     });
-    if (result.css) {
-      this.data = result.css;
-    } else {
-      this.data = result;
-    }
+    this.data = result.css || result;
   } catch(err) {
     var error = sassError(err);
     throw error;

--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -65,11 +65,16 @@ function sassError(ctx /*, options*/) {
 // Render data
 SassEngine.prototype.evaluate = function (context/*, locals*/) {
   try {
-    this.data = sass.renderSync({
+    var result = sass.renderSync({
       data:         this.data,
       includePaths: [ path.dirname(this.file) ].concat(context.environment.paths),
       indentedSyntax: /^.*\.sass$/.test(this.file)
     });
+    if (result.css) {
+      this.data = result.css;
+    } else {
+      this.data = result;
+    }
   } catch(err) {
     var error = sassError(err);
     throw error;


### PR DESCRIPTION
node-sass changed its API starting with 2.0.0-beta as seen here https://github.com/sass/node-sass/releases/tag/v2.0.0-beta

The renderSync return value is now an object and the rendered result is in {return value}.css.