### PR TITLE
Sass importer

### DIFF
--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -66,6 +66,7 @@ function sassError(ctx /*, options*/) {
 SassEngine.prototype.evaluate = function (context/*, locals*/) {
   try {
     var result = sass.renderSync({
+      file:         this.file,
       data:         this.data,
       includePaths: [ path.dirname(this.file) ].concat(context.environment.paths),
       indentedSyntax: /^.*\.sass$/.test(this.file)

--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -17,6 +17,7 @@
 
 // stdlib
 var path = require('path');
+var util = require('util');
 
 // 3rd-party
 var _ = require('lodash');
@@ -26,6 +27,7 @@ var sass; // initialized later
 // internal
 var Template  = require('../template');
 var prop      = require('../common').prop;
+var logger    = require('../logger');
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -102,35 +104,32 @@ function isFileNotFound(error) {
 }
 
 
-SassEngine.prototype.sassImporter = function (context, url, prev) {
-
-  function tryDepend(importPath) {
-    if (importPath) {
-      try {
-        context.dependOn(importPath);
-      } catch (error) {
-        return error;
-      }
+function tryDepend(context, importPath) {
+  if (importPath) {
+    try {
+      context.dependOn(importPath);
+    } catch (error) {
+      return error;
     }
   }
+}
 
+
+SassEngine.prototype.sassImporter = function (context, url, prev) {
   var importPath = importArgumentRelativeToSearchPaths(prev, url, context.environment.__trail__.paths);
   // "If you have a SCSS or Sass file that you want to import but don't want to compile to a CSS file, you can add an
   // underscore to the beginning of the filename. ... You can then import these files without using the underscore."
   // https://github.com/sass/sass/blob/d26e6f/doc-src/SASS_REFERENCE.md#partials-partials
   var underscoredImportPath = importPath && path.join(path.dirname(importPath), '_' + path.basename(importPath));
 
-  var firstError = tryDepend(importPath);
-  var secondError;
-  if (isFileNotFound(firstError)) {
-    secondError = tryDepend(underscoredImportPath);
-  }
+  var firstError = tryDepend(context, importPath);
+  var secondError = isFileNotFound(firstError) && tryDepend(context, underscoredImportPath);
 
   // While @import()ing assets outside of the search paths should be strongly discouraged, it is valid. Because the
   // asset is outside of the search path, there's no way to call depend_on() on it, so we shouldn't throw an error.
   if (isFileNotFound(firstError) && isFileNotFound(secondError)) {
-    console.warn('%s will not change when %s changes, because the file could not be found.', prev, url,
-      firstError.message, secondError.message);
+    logger.warn(util.format('%s will not change when %s changes, because the file could not be found.', prev, url,
+      firstError.message, secondError.message));
   }
 
   return {

--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -64,10 +64,15 @@ function sassError(ctx /*, options*/) {
 
 // Render data
 SassEngine.prototype.evaluate = function (context/*, locals*/) {
+  var self = this;
+
   try {
     var result = sass.renderSync({
       file:         this.file,
       data:         this.data,
+      importer:     function(url, prev) {
+        return self.sassImporter(context, url, prev);
+      },
       includePaths: [ path.dirname(this.file) ].concat(context.environment.paths),
       indentedSyntax: /^.*\.sass$/.test(this.file)
     });
@@ -79,6 +84,59 @@ SassEngine.prototype.evaluate = function (context/*, locals*/) {
   }
 };
 
+
+// Returns the argument of the @import() call relative to the asset search paths.
+function importArgumentRelativeToSearchPaths(importer, importArgument, searchPaths) {
+  var importAbsolutePath = path.resolve(path.dirname(importer), importArgument);
+  var importSearchPath = _.find(searchPaths, function(path) {
+    return importAbsolutePath.indexOf(path) === 0;
+  });
+  if (importSearchPath) {
+    return path.relative(importSearchPath, importAbsolutePath);
+  }
+}
+
+
+function isFileNotFound(error) {
+  return error && error.code === 'FileNotFound';
+}
+
+
+SassEngine.prototype.sassImporter = function (context, url, prev) {
+
+  function tryDepend(importPath) {
+    if (importPath) {
+      try {
+        context.dependOn(importPath);
+      } catch (error) {
+        return error;
+      }
+    }
+  }
+
+  var importPath = importArgumentRelativeToSearchPaths(prev, url, context.environment.__trail__.paths);
+  // "If you have a SCSS or Sass file that you want to import but don't want to compile to a CSS file, you can add an
+  // underscore to the beginning of the filename. ... You can then import these files without using the underscore."
+  // https://github.com/sass/sass/blob/d26e6f/doc-src/SASS_REFERENCE.md#partials-partials
+  var underscoredImportPath = importPath && path.join(path.dirname(importPath), '_' + path.basename(importPath));
+
+  var firstError = tryDepend(importPath);
+  var secondError;
+  if (isFileNotFound(firstError)) {
+    secondError = tryDepend(underscoredImportPath);
+  }
+
+  // While @import()ing assets outside of the search paths should be strongly discouraged, it is valid. Because the
+  // asset is outside of the search path, there's no way to call depend_on() on it, so we shouldn't throw an error.
+  if (isFileNotFound(firstError) && isFileNotFound(secondError)) {
+    console.warn('%s will not change when %s changes, because the file could not be found.', prev, url,
+      firstError.message, secondError.message);
+  }
+
+  return {
+    file: url
+  };
+};
 
 // Expose default MimeType of an engine
 prop(SassEngine, 'defaultMimeType', 'text/css');

--- a/test/engines_test.js
+++ b/test/engines_test.js
@@ -1,8 +1,27 @@
-/* global describe, it */
+/* global describe, it, after */
 
 'use strict';
 
 var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+
+function assetPath(filename) {
+  return path.join(__dirname, 'fixtures', filename);
+}
+
+function copySync(src, dest) {
+  fs.writeFileSync(dest, fs.readFileSync(src));
+}
+
+function bumpMtimeSync(pathname) {
+  var stat = fs.statSync(pathname);
+  var oneSecond = 1000;
+  // "time_t provides times accurate to one second."
+  // http://en.wikipedia.org/wiki/Stat_%28system_call%29#Time_granularity
+  var newMtime = new Date(stat.mtime.getTime() + oneSecond);
+  fs.utimesSync(pathname, stat.atime, newMtime);
+}
 
 describe('Engines', function () {
   var env = require('./environment')();
@@ -50,9 +69,27 @@ describe('Engines', function () {
   });
 
   describe('SASS', function () {
+    var variablesPath = assetPath('sass_engine/_variables.css.scss');
+
+    after(function() {
+      fs.unlinkSync(variablesPath);
+    });
+
     it('should process stylesheets', function () {
+      copySync(assetPath('sass_engine/_variables.css.scss.v1'), variablesPath);
+
       var asset = env.findAsset('sass_engine/stylesheet');
       assert(asset.toString().match(/\.foo\s+\.bar\s*\{/));
+      assert(asset.toString().match(/\.column\s+\{\s+width:\s*30px/));
+    });
+
+    it('should process changes to stylesheets', function () {
+      copySync(assetPath('sass_engine/_variables.css.scss.v2'), variablesPath);
+      bumpMtimeSync(variablesPath);
+
+      var asset = env.findAsset('sass_engine/stylesheet');
+      assert(asset.toString().match(/\.foo\s+\.bar\s*\{/));
+      assert(asset.toString().match(/\.column\s+\{\s+width:\s*40px/));
     });
   });
 });

--- a/test/fixtures/sass_engine/_variables.css.scss.v1
+++ b/test/fixtures/sass_engine/_variables.css.scss.v1
@@ -1,0 +1,1 @@
+$column_width: 30px;

--- a/test/fixtures/sass_engine/_variables.css.scss.v2
+++ b/test/fixtures/sass_engine/_variables.css.scss.v2
@@ -1,0 +1,1 @@
+$column_width: 40px;

--- a/test/fixtures/sass_engine/grid.css.scss
+++ b/test/fixtures/sass_engine/grid.css.scss
@@ -1,0 +1,5 @@
+@import 'variables.css.scss';
+
+.column {
+  width: $column_width;
+}

--- a/test/fixtures/sass_engine/stylesheet.css.scss
+++ b/test/fixtures/sass_engine/stylesheet.css.scss
@@ -1,3 +1,5 @@
+@import 'grid.css.scss';
+
 .foo {
   .bar {
     color: red;


### PR DESCRIPTION
noticed that a hook into sass's `@import()` statement [was recently added](https://github.com/sass/node-sass/commit/9026ed1467fea36c2bbf916e946ff18bfee064ab) to `node-sass`, so I figured I'd take a stab at writing integration for it!

the code probably needs some work before it would be suitable for merge.

some particular concerns:
- [x] test coverage?
- [ ] avoid clobbering configuration from `DirectiveProcessor`?
- [ ] are there path utilities elsewhere in the codebase that I could use instead of the code I've written? (a particularly useful one would be "given an absolute path, return a path relative to one of the search paths")
- [ ] how should the "file not found" error be handled? since the sass compiler will likely fail and this code is only intended to be a workflow optimization, this code should likely avoid failing.