### PR TITLE
TypeError: Argument must be a string

### DIFF
--- a/lib/mincer/assets/processed.js
+++ b/lib/mincer/assets/processed.js
@@ -146,7 +146,12 @@ var ProcessedAsset = module.exports = function ProcessedAsset() {
   this.__source__ = result.data;
   this.sourceMap  = result.map;
 
-  this.length = Buffer.byteLength(this.source);
+  if (this.source instanceof Buffer) {
+    this.length = this.source.length;
+  } else {
+    this.length = Buffer.byteLength(this.source);
+  }
+
   this.digest = this.environment.digest.update(this.source).digest('hex');
 
   buildRequiredAssets(this, context);


### PR DESCRIPTION
fix bug: if this.source is Buffer then Buffer.byteLength(this.source) throw exception