### PR TITLE
Support ejs ~ 2.*

### DIFF
--- a/lib/mincer/engines/ejs_engine.js
+++ b/lib/mincer/engines/ejs_engine.js
@@ -50,9 +50,16 @@ EjsEngine.prototype.evaluate = function (context, locals) {
     return;
   }
 
-  this.data = ejs.render(this.data, {
-    filename: context.pathname,
-    scope:    context,
-    locals:   locals
-  });
+  if (ejs.VERSION) { // ejs 2.x.x
+    this.data = ejs.render(this.data, locals, {
+      filename: context.pathname,
+      context:  context
+    });
+  } else { // ejs 1.x.x
+    this.data = ejs.render(this.data, {
+      filename: context.pathname,
+      scope:    context,
+      locals:   locals
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "connect": "*",
     "csso": "*",
     "csswring": "*",
-    "ejs": "~ 1.*",
+    "ejs": "*",
     "eslint": "0.10.2",
     "eslint-plugin-nodeca": "~1.0.3",
     "jade": "*",

--- a/test/engines_test.js
+++ b/test/engines_test.js
@@ -45,7 +45,7 @@ describe('Engines', function () {
       it('should compile to a JS function', function () {
         var asset = env.findAsset('jst_engine/ejs/template');
         assert(asset.toString().match(/this\.JST/));
-        assert(asset.toString().match(/buf\.push/));
+        assert(asset.toString().match(/__output\.push/));
       });
     });
 


### PR DESCRIPTION
The latest version of [ejs][1] doesn't work with mincer as it has a slightly different signature for `render`. This patch updates the ejs dependency and fixes the deprecation warning "`scope` option is deprecated and will be removed in EJS 3".

[1]: https://github.com/mde/ejs