### PR TITLE
Updated autoprefixer call for version >= 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ you can [search existing extentions](https://www.npmjs.org/browse/keyword/mincer
 in npm.
 
 
+## Notice on upgrade 1.2.x -> 1.3.x
+
+If your project is using `autoprefixer-core` or `csswring`:
+
+- include `postcss` >= 4.1
+
+
 ## Notice on upgrade 1.1.x -> 1.2.x
 
 Update dependencies in your project, if use these:
@@ -220,7 +227,7 @@ to write CSS assets in Mincer. Use the extension `.css.less`.
 
 ### Styling with Sass
 
-[Sass](http://sass-lang.com/) is an extension of CSS3, adding nested rules, 
+[Sass](http://sass-lang.com/) is an extension of CSS3, adding nested rules,
 variables, mixins, selector inheritance, and more.
 
 If the `node-sass` Node module is available to your application, you can use Sass

--- a/lib/mincer/compressors/csswring_compressor.js
+++ b/lib/mincer/compressors/csswring_compressor.js
@@ -18,7 +18,7 @@
 
 // 3rd-party
 var path      = require('path');
-var csswring; // initialized later
+var csswring, postcss, compile; // initialized later
 
 
 // internal
@@ -33,6 +33,23 @@ var prop     = require('../common').prop;
 var CsswringCompressor = module.exports = function CsswringCompressor() {
   Template.apply(this, arguments);
   csswring = csswring || Template.libs.csswring || require('csswring');
+  try {
+    postcss = postcss || Template.libs.postcss || require('postcss');
+  } catch(e) {
+    // Fail silently for now
+  }
+
+  if (postcss && postcss.plugin &&
+      csswring.postcss && csswring.postcss.postcssPlugin) {
+    // Use newer API for csswring if it supports the Postcss plugin API
+    compile = function (css, config) {
+      return postcss([ csswring(config) ]).process(css);
+    };
+  } else {
+    compile = function (css, config) {
+      return csswring.wring(css, config);
+    };
+  }
 };
 
 
@@ -44,14 +61,14 @@ CsswringCompressor.prototype.evaluate = function (context/*, locals*/) {
   var result;
 
   if (!context.environment.isEnabled('source_maps')) {
-    this.data = csswring.wring(this.data).css;
+    this.data = compile(this.data).css;
     return;
   }
 
   // Reset sourceRoot bebore process - we work with relative paths
   var map = context.createSourceMapObject(this);
 
-  result = csswring.wring(this.data, {
+  result = compile(this.data, {
     map: {
       prev: map,
       inline: false

--- a/lib/mincer/processors/autoprefixer.js
+++ b/lib/mincer/processors/autoprefixer.js
@@ -2,9 +2,10 @@
  *  class Autoprefixer
  *
  *  Post processor that runs autoprefixer for css. You will need `autoprefixer`
- *  Node module installed:
+ *  and `postcss` Node modules installed:
  *
  *      npm install autoprefixer
+ *      npm install postcss
  *
  *
  *  ##### SUBCLASS OF
@@ -19,7 +20,7 @@
 // 3rd-party
 var _    = require('lodash');
 var path = require('path');
-var autoprefixer; // initialized later
+var autoprefixer, postcss; // initialized later
 
 
 // internal
@@ -33,6 +34,12 @@ var Template = require('../template');
 var Autoprefixer = module.exports = function Autoprefixer() {
   Template.apply(this, arguments);
   autoprefixer = autoprefixer || Template.libs.autoprefixer || require('autoprefixer-core');
+  try {
+    postcss = postcss || Template.libs.postcss || require('postcss');
+  } catch(e) {
+    // Fail silently for now
+    // A warning will appear every time when ap.process() is called.
+  }
 };
 
 
@@ -66,9 +73,14 @@ Autoprefixer.prototype.evaluate = function (context/*, locals*/) {
   var ap = autoprefixer({ browsers: requirements }), result;
 
   if (!ap.process) {
-    // Old API, < v1.0
+    // Old API, autoprefixer < v1.0
     this.data = ap.compile(this.data);
     return;
+  }
+
+  if (postcss && postcss.plugin) {
+    // Newer API for autoprefixer-core >= 5.2
+    ap = postcss([ ap ]);
   }
 
   if (!context.environment.isEnabled('source_maps')) {


### PR DESCRIPTION
Starting from `autoprefixer-core` 5.2, the `ap.process()` is obsolete (Ref: postcss/autoprefixer-core@d35c9321e2ca956fafc82e443e3b2cd06c21aaab). This PR aims to fix this by updating the call to the newer recommended way.

Please advise. Thanks.