### PR TITLE
Support node-sass 3 error objects

### DIFF
--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -51,13 +51,17 @@ require('util').inherits(SassEngine, Template);
 // helper to generate human-friendly errors.
 // adapted version from less_engine.js
 function sassError(ctx /*, options*/) {
-  // libsass error string format: path:line: error: message
-  var error = _.zipObject(
-    [ 'path', 'line', 'level', 'message' ],
-    ctx.split(':', 4).map(function(str) { return str.trim(); })
-  );
-  if (error.line && error.level && error.message) {
-    return new Error('Line ' + error.line + ': ' + error.message);
+  if (ctx.line && ctx.message) { // libsass 3.x error object
+    return new Error('Line ' + ctx.line + ': ' + ctx.message);
+  }
+  if (typeof ctx === 'string') { // libsass error string format: path:line: error: message
+    var error = _.zipObject(
+      [ 'path', 'line', 'level', 'message' ],
+      ctx.split(':', 4).map(function(str) { return str.trim(); })
+    );
+    if (error.line && error.level && error.message) {
+      return new Error('Line ' + error.line + ': ' + error.message);
+    }
   }
 
   return new Error(ctx);


### PR DESCRIPTION
Node-Sass now returns proper Error objects (see [here](https://github.com/sass/node-sass#error-object)) instead of Strings. Therefore the `ctx.split` call fails, throwing another exception which effectively hides the Sass error message. This is just a quick PR to support the new error objects (leaving in support for the string errors) -- if you're interested in merging this, let me know if you want me to change anything!