### PR TITLE
Make SassEngine configurable

### DIFF
--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -48,6 +48,27 @@ var SassEngine = module.exports = function SassEngine() {
 require('util').inherits(SassEngine, Template);
 
 
+// Internal (private) options storage
+var options = {};
+
+/**
+ *  SassEngine.configure(opts) -> Void
+ *  - opts (Object):
+ *
+ *  Allows to set Sass compilation opts.
+ *
+ *  Default: `{}`.
+ *
+ *
+ *  ##### Example
+ *
+ *      SassEngine.configure({ sourceComments: true });
+ **/
+SassEngine.configure = function (opts) {
+  options = _.clone(opts);
+};
+
+
 // helper to generate human-friendly errors.
 // adapted version from less_engine.js
 function sassError(ctx /*, options*/) {
@@ -73,7 +94,7 @@ SassEngine.prototype.evaluate = function (context, locals) {
   var self = this;
 
   try {
-    var result = sass.renderSync({
+    var result = sass.renderSync(_.assign({}, options, {
       file:         this.file,
       data:         this.data,
       importer:     function(url, prev) {
@@ -82,7 +103,7 @@ SassEngine.prototype.evaluate = function (context, locals) {
       functions:    this.sassFunctions(locals),
       includePaths: [ path.dirname(this.file) ].concat(context.environment.paths),
       indentedSyntax: /^.*\.sass$/.test(this.file)
-    });
+    }));
 
     this.data = String(result.css || result);
   } catch(err) {

--- a/test/engines_test.js
+++ b/test/engines_test.js
@@ -25,6 +25,7 @@ function bumpMtimeSync(pathname) {
 
 describe('Engines', function () {
   var env = require('./environment')();
+  var Mincer = require('..');
 
   describe('EJS', function () {
     it('should process javascripts', function () {
@@ -96,6 +97,14 @@ describe('Engines', function () {
       var asset = env.findAsset('sass_engine/helpers');
       assert(asset.toString().match(/\/assets\/ixti-[a-f0-9]{32}.gif/));
       assert(asset.toString().match(/data:image\/gif;base64/));
+    });
+
+    it('should be configurable', function () {
+      Mincer.SassEngine.configure({ outputStyle: 'compressed' });
+      bumpMtimeSync(assetPath('sass_engine/grid.css.scss'));
+
+      var asset = env.findAsset('sass_engine/grid');
+      assert(asset.toString().match(/\.column\{width:40px/));
     });
   });
 });


### PR DESCRIPTION
This just adds a .configure method to SassEngine similar to the one available for other engines.