### PR TITLE
Add Sass SourceMap support

### DIFF
--- a/examples/assets/stylesheets/_helper.scss
+++ b/examples/assets/stylesheets/_helper.scss
@@ -1,0 +1,5 @@
+$h1-color: aliceblue;
+
+body {
+  background: url(image_path("stripes.png"));
+}

--- a/examples/assets/stylesheets/alt.css.scss
+++ b/examples/assets/stylesheets/alt.css.scss
@@ -1,0 +1,10 @@
+@import "helper";
+
+body {
+  transition: transform 1s;
+
+  h2 {
+    color: $h1-color;
+    background-color: rgb(255,255,255);
+  }
+}

--- a/examples/manifest.js
+++ b/examples/manifest.js
@@ -28,7 +28,7 @@ var manifest = new Mincer.Manifest(environment, path.join(__dirname, 'public', '
 
 
 try {
-  var assetsData = manifest.compile([ 'app.js', 'app.css', 'stripes.png' ], {
+  var assetsData = manifest.compile([ 'app.js', 'app.css', 'alt.css', 'stripes.png' ], {
     compress: true,
     sourceMaps: true,
     embedMappingComments: true

--- a/examples/views/layout.jade
+++ b/examples/views/layout.jade
@@ -3,9 +3,11 @@ html(lang='en')
   head
     title Mincer demo
     !=stylesheet('app.css')
+    !=stylesheet('alt.css')
 
   body
     .container
-      h1 Mincer demo
+      h1 Mincer
+      h2 Demo
 
     !=javascript('app.js')

--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -49,7 +49,11 @@ require('util').inherits(SassEngine, Template);
 
 
 // Internal (private) options storage
-var options = {};
+var options = {
+  sourceComments: false,
+  omitSourceMapUrl: true,
+  sourceMapContents: true
+};
 
 /**
  *  SassEngine.configure(opts) -> Void
@@ -65,7 +69,7 @@ var options = {};
  *      SassEngine.configure({ sourceComments: true });
  **/
 SassEngine.configure = function (opts) {
-  options = _.clone(opts);
+  options = _.assign({}, options, opts);
 };
 
 
@@ -91,25 +95,45 @@ function sassError(ctx /*, options*/) {
 
 // Render data
 SassEngine.prototype.evaluate = function (context, locals) {
-  var self = this;
+  var withSourcemap = context.environment.isEnabled('source_maps');
 
   try {
     var result = sass.renderSync(_.assign({}, options, {
-      file:         this.file,
-      data:         this.data,
-      importer:     function(url, prev) {
-        return self.sassImporter(context, url, prev);
-      },
-      functions:    this.sassFunctions(locals),
-      includePaths: [ path.dirname(this.file) ].concat(context.environment.paths),
-      indentedSyntax: /^.*\.sass$/.test(this.file)
+      file:           this.file,
+      data:           this.data,
+      importer:       this.sassImporter.bind(this, context),
+      functions:      this.sassFunctions(locals),
+      includePaths:   [ path.dirname(this.file) ].concat(context.environment.paths),
+      indentedSyntax: /^.*\.sass$/.test(this.file),
+      outFile:        path.basename(this.file).replace(/\.(sass|scss)$/, ''),
+      sourceMap:      withSourcemap
     }));
 
     this.data = String(result.css || result);
+
+    if (withSourcemap) {
+      this.map = this.normalizeSourceMap(context, String(result.map));
+    }
+
   } catch(err) {
     var error = sassError(err);
     throw error;
   }
+};
+
+
+SassEngine.prototype.normalizeSourceMap = function (context, map) {
+  map = JSON.parse(map);
+
+  var root = context.environment.root;
+  var base = path.dirname(this.file);
+
+  // Make sure all source paths are relative to the processed file!
+  map.sources = map.sources.map(function (source) {
+    return path.relative(base, path.join(root, source));
+  });
+
+  return JSON.stringify(map);
 };
 
 
@@ -163,6 +187,15 @@ SassEngine.prototype.sassImporter = function (context, url, prev) {
   };
 };
 
+function isSassType(obj) {
+  for (var type in sass.types) {
+    if (sass.types.hasOwnProperty(type)) {
+      if (obj instanceof sass.types[type]) { return true; }
+    }
+  }
+
+  return false;
+}
 
 SassEngine.prototype.sassFunctions = function (locals) {
   return _.transform(locals, function (out, fn, key) {
@@ -196,6 +229,9 @@ SassEngine.prototype.sassFunctions = function (locals) {
         return new sass.types.Number(result);
       case 'boolean':
         return new sass.types.Boolean(result);
+      case 'object':
+        if (isSassType(result)) { return result; }
+        // otherwise fall through and throw!
       default:
         throw new Error('Unsupported value: ' + result);
       }


### PR DESCRIPTION
This adds Sass SourceMap support, but needs a review by someone with better knowledge of Mincer's SourceMap internals.

So far this just enables SourceMaps and writes the result back to the `map` property; however I believe we may have to make a few adjustments to the SourceMap contents to make it play ball with Mincer for bundled assets and further processing (`csswring` or `autoprefixer` specifically).

Here is an example of the map currently generated for one of the Sass fixtures:

    {
      version: 3,
      file: 'stylesheet.css',
      sources: [
        '../test/fixtures/sass_engine/stylesheet.css.scss',
        '../test/fixtures/sass_engine/grid.css.scss',
        '../test/fixtures/sass_engine/_variables.css.scss'
      ],
      sourcesContent: [],
      mappings: 'ACEA,OAAO,CAAC;EACN,KAAK,ECHQ,IAAI,GDEV;;ADCP,IAAI,CAAC,IAAI,CAAJ;EACH,KAAK,EAAE... (length: 90)',
      names: []
    }

Does that look good or do we need to make any adjustments to the `file` and `sources` properties? Any pointers much appreciated!

Furthermore, I have not enabled `sourcesContent` (figuring, if somebody has issues hosting the sources, they can still enable the option using via `SassEngine.configure`).