### PR TITLE
change autoprefixer-core back to autoprefixer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -218,7 +218,7 @@
 
 - Fixed `eco` engine
 - Fixed gzipped asets generation
-- Synced with `sprockets` 2.10.0 
+- Synced with `sprockets` 2.10.0
 
 
 0.5.3 / 2013-08-01

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ in npm.
 
 ## Notice on upgrade 1.2.x -> 1.3.x
 
-If your project is using `autoprefixer-core` or `csswring`:
+If your project is using `autoprefixer` or `csswring`:
 
 - include `postcss` >= 4.1
 
@@ -36,7 +36,6 @@ If your project is using `autoprefixer-core` or `csswring`:
 
 Update dependencies in your project, if use these:
 
-- replace `autoprefixer` -> `autoprefixer-core`
 - upgrade `csswring` 1.x -> 2.x
 
 

--- a/lib/mincer/processors/autoprefixer.js
+++ b/lib/mincer/processors/autoprefixer.js
@@ -33,7 +33,7 @@ var Template = require('../template');
 // Class constructor
 var Autoprefixer = module.exports = function Autoprefixer() {
   Template.apply(this, arguments);
-  autoprefixer = autoprefixer || Template.libs.autoprefixer || require('autoprefixer-core');
+  autoprefixer = autoprefixer || Template.libs.autoprefixer || require('autoprefixer');
   try {
     postcss = postcss || Template.libs.postcss || require('postcss');
   } catch(e) {
@@ -79,7 +79,7 @@ Autoprefixer.prototype.evaluate = function (context/*, locals*/) {
   }
 
   if (postcss && postcss.plugin) {
-    // Newer API for autoprefixer-core >= 5.2
+    // Newer API for autoprefixer >= 6.0
     ap = postcss([ ap ]);
   }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "source-map": "~ 0.1.40"
   },
   "devDependencies": {
-    "autoprefixer-core": "*",
+    "autoprefixer": "*",
     "coffee-script": "*",
     "connect": "*",
     "csso": "*",


### PR DESCRIPTION
This changes `autoprefixer-core` back to `autoprefixer` due to the merging of the 2 repos. Regarding #210 