### PR TITLE
Solve issue in latest autoprefixer with sourcemaps

### DIFF
--- a/lib/mincer/compressors/csswring_compressor.js
+++ b/lib/mincer/compressors/csswring_compressor.js
@@ -69,7 +69,7 @@ CsswringCompressor.prototype.evaluate = function (context/*, locals*/) {
 
   result = postcss([ csswring(config) ]).process(this.data, config);
 
-  this.map  = result.map;
+  this.map  = result.map.toString();
   this.data = result.css;
 };
 

--- a/lib/mincer/processors/autoprefixer.js
+++ b/lib/mincer/processors/autoprefixer.js
@@ -85,6 +85,6 @@ Autoprefixer.prototype.evaluate = function (context/*, locals*/) {
     to:   path.basename(context.pathname)
   });
 
-  this.map  = result.map;
+  this.map  = result.map.toString();
   this.data = result.css;
 };


### PR DESCRIPTION
Autoprefixer would set the map to an instance of `SourceMapGenerator` which would fail since `context.createSourceMapObject` wouldn't expect `obj.map` to be anything other than a JSON string.

Fixes #214