### PR TITLE
Fix Windows paths problem in logicalPath, fix tests

### DIFF
--- a/lib/mincer/asset_attributes.js
+++ b/lib/mincer/asset_attributes.js
@@ -74,10 +74,14 @@ getter(AssetAttributes.prototype, 'searchPaths', function () {
  *  path will be incorrect.
  **/
 getter(AssetAttributes.prototype, 'logicalPath', function () {
-  var pathname = this.pathname, paths = this.environment.paths, root_path;
+  var pathname = this.pathname,
+      paths = this.environment.paths,
+      unix_path = pathname.replace(/\\/g, '/'),
+      root_path;
 
   root_path = _.find(paths, function (root) {
-    return path.join(root, '/') === pathname.substr(0, root.length + 1);
+    root = path.join(root, '/').replace(/\\/g, '/');
+    return root === unix_path.substr(0, root.length);
   });
 
   if (!root_path) {

--- a/test/examples_test.js
+++ b/test/examples_test.js
@@ -17,7 +17,7 @@ describe('Examples', function () {
     // Turn on compression modules for CSS & JS
     var env = _.assign({}, process.env, { NODE_ENV: 'production' });
 
-    srv = child.spawn(path.join(__dirname, '../examples/server.js'), [], { env: env });
+    srv = child.spawn('node', [ path.join(__dirname, '../examples/server.js') ], { env: env });
 
     setTimeout(done, 1000);
   });
@@ -32,7 +32,7 @@ describe('Examples', function () {
 
 
   it('Manifest run', function (done) {
-    child.exec(path.join(__dirname, '../examples/manifest.js'), function (err) {
+    child.exec('node ' + path.join(__dirname, '../examples/manifest.js'), function (err) {
       if (err) {
         done(err);
         return;


### PR DESCRIPTION
I have changed implementation of `logicalPath` getter in [AssetAttributes](https://github.com/nodeca/mincer/blob/master/lib/mincer/asset_attributes.js) to avoid 'File outside paths' error on Windows in some cases.
Also I have modified [examples_test.js](https://github.com/nodeca/mincer/blob/master/test/examples_test.js) to run in different environments (e.g. on Windows).