### PR TITLE
Update readme to specify which "latest" for csswring and autoprefixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ in npm.
 
 If your project is using `autoprefixer` or `csswring` processors:
 
-- upgrade `csswring` & `autoprefixer` to latest
+- upgrade `csswring` to >=4.x and `autoprefixer` to >= 6.x
   - if you used legacy `autoprefixer-core` package, replace it with `autoprefixer`
 - include `postcss` >= 4.1
 


### PR DESCRIPTION
Without adding this it's ambiguous which versions are supported.

I've determined these versions are the minimums based on the date of this change versus the dates of the released in each project.