### PR TITLE
Add option to skip XSSI protection header when writing sourcemap to file

### DIFF
--- a/lib/mincer/manifest.js
+++ b/lib/mincer/manifest.js
@@ -176,6 +176,7 @@ function gzip(data) {
  *  - `embedMappingComments` (false) - set `true` to embed sourcemap url
  *    into created files
  *  - `compress` (false) - set `true` to also create gzipped files
+ *  - `noSourceMapProtection` (false) - set `true` to skip adding XSSI protection header
  *
  *  Compile and write asset(s) to directory. The asset is written to a
  *  fingerprinted filename like `app-2e8e9a7c6b0aafa0c9bdeec90ea30213.js`.
@@ -258,10 +259,17 @@ Manifest.prototype.compile = function (files, options) {
     }
 
     if (asset.sourceMap) {
-      // add XSSI protection header
-      write(target + '.map', asset.mtime, ')]}\'\n' + asset.sourceMap);
+      // XSSI protection header enabled by default
+      var header = ')]}\'\n';
+
+      // Optionally skip XSSI protection header
+      if (options.noSourceMapProtection) {
+        header = '';
+      }
+
+      write(target + '.map', asset.mtime, header + asset.sourceMap);
       if (options.compress) {
-        write(target + '.map.gz', asset.mtime, gzip(')]}\'\n' + asset.sourceMap));
+        write(target + '.map.gz', asset.mtime, gzip(header + asset.sourceMap));
       }
     }
 


### PR DESCRIPTION
When serving the source map files directly, it is true a protection header is a must. However in certain use cases where we need a valid source map file for some other private reader (Raygun for example), the XSSI protection header turns out to be problematic.

Please see the original discussion over at connect-assets: https://github.com/adunkman/connect-assets/issues/345

