### PR TITLE
Support HTML as part of the directive processor

### DIFF
--- a/lib/mincer/processors/directive_processor.js
+++ b/lib/mincer/processors/directive_processor.js
@@ -60,14 +60,17 @@ function get_lines(str) {
 // Directives in comments after the first non-whitespace line
 // of code will not be processed.
 var HEADER_PATTERN = new RegExp(
-  '^(?:\\s*' +
+    '^(?:\\s*' +
     '(' +
-      '(?:\/[*](?:\\s*|.+?)*?[*]\/)' + '|' +
-      '(?:###\n(?:\\s*|.+?)*?\n###)' + '|' +
-      '(?:\/\/.*\n?)+' + '|' +
-      '(?:#.*\n?)+' +
+    '(?:\/[*](?:\\s*|.+?)*?[*]\/)' + '|' +
+    '(?:###\n(?:\\s*|.+?)*?\n###)' + '|' +
+
+    '(?:\<!--(?:\\s*|.+?)*?--\>)' + '|' + //Include HTML files
+
+    '(?:\/\/.*\n?)+' + '|' +
+    '(?:#.*\n?)+' +
     ')*' +
-  ')*', 'm');
+    ')*', 'm');
 
 
 // Directives are denoted by a `=` followed by the name, then


### PR DESCRIPTION
It would be really nice to bundle HTML files in the same way that CSS and JS are. It only requires a small change to the regex and the inclusion of the HTML MIME type.

```
var HEADER_PATTERN = new RegExp(
    '^(?:\\s*' +
    '(' +
    '(?:\/[*](?:\\s*|.+?)*?[*]\/)' + '|' +
    '(?:###\n(?:\\s*|.+?)*?\n###)' + '|' +

    '(?:\<!--(?:\\s*|.+?)*?--\>)' + '|' + //Include HTML files

    '(?:\/\/.*\n?)+' + '|' +
    '(?:#.*\n?)+' +
    ')*' +
    ')*', 'm');
```

Then simply set the mime type and plugin the direective processor

```
Mincer.registerMimeType('text/html', '.html');
Mincer.registerPreProcessor('text/html', Mincer.DirectiveProcessor);
```

I'd welcome your thoughts.
