### PR TITLE
Option to include/ignore files depending on NODE_ENV

### DIFF
--- a/lib/mincer/processors/directive_processor.js
+++ b/lib/mincer/processors/directive_processor.js
@@ -79,8 +79,28 @@ var HEADER_PATTERN = new RegExp(
 //     //= require foo
 //     //= require "foo"
 //
-var DIRECTIVE_PATTERN = new RegExp('^\\W*=\\s*(\\w+.*?)(\\*\\/)?$');
+// If you want to include a specific file only when
+// developing/staging/in production you can add
+// dev/stage/prod before the equal sign (=).
+//
+// Examples:
+//
+//     //dev= require foo
+//     // dev =require foo
+//     //dev =require foo
+//     //development=require foo
+//     //prod=require foo
+//     //production=require foo
+//     //stage=require foo
+//     //staging=require foo
+//
+//
 
+var DIRECTIVE_PATTERN = new RegExp('^\\W*(dev|development|prod|production|stage|staging)?\\W*=\\s*(\\w+.*?)(\\*\\/)?$', 'i');
+
+var PRODUCTION_IGNORES = ['dev', 'development', 'stage', 'staging'];
+var STAGING_IGNORES = ['dev', 'development', 'prod', 'production'];
+var DEVELOPMENT_IGNORES = ['stage', 'staging', 'prod', 'production'];
 
 // Real directive processors
 var DIRECTIVE_HANDLERS = {
@@ -405,8 +425,23 @@ getter(DirectiveProcessor.prototype, 'directives', function () {
     get_lines(this.header).forEach(function (line, index) {
       var matches = DIRECTIVE_PATTERN.exec(line), name, args;
 
-      if (matches && matches[1]) {
-        args = shellwords(matches[1]);
+      if (matches && matches[2]) {
+
+        if(process.env.NODE_ENV === 'production' || process.env.NODE_ENVIRONMENT === 'production') {
+          if(PRODUCTION_IGNORES.indexOf(matches[1].toLoweCase()) !== -1) {
+            return;
+          }
+        } else if(process.env.NODE_ENV === 'staging' || process.env.NODE_ENVIRONMENT === 'staging') {
+          if(STAGING_IGNORES.indexOf(matches[1].toLoweCase()) !== -1) {
+            return;
+          }
+        } else { // Default is development
+          if(DEVELOPMENT_IGNORES.indexOf(matches[1].toLoweCase()) !== -1) {
+            return;
+          }
+        }
+
+        args = shellwords(matches[2]);
         name = args.shift();
 
         if (_.isFunction(DIRECTIVE_HANDLERS[name])) {

--- a/lib/mincer/processors/directive_processor.js
+++ b/lib/mincer/processors/directive_processor.js
@@ -96,11 +96,13 @@ var HEADER_PATTERN = new RegExp(
 //
 //
 
-var DIRECTIVE_PATTERN = new RegExp('^\\W*(dev|development|prod|production|stage|staging)?\\W*=\\s*(\\w+.*?)(\\*\\/)?$', 'i');
+var DIRECTIVE_PATTERN = new RegExp(
+  '^\\W*(dev|development|prod|production|stage|staging)?\\W*=\\s*(\\w+.*?)(\\*\\/)?$', 'i'
+);
 
-var PRODUCTION_IGNORES = ['dev', 'development', 'stage', 'staging'];
-var STAGING_IGNORES = ['dev', 'development', 'prod', 'production'];
-var DEVELOPMENT_IGNORES = ['stage', 'staging', 'prod', 'production'];
+var PRODUCTION_IGNORES = [ 'dev', 'development', 'stage', 'staging' ];
+var STAGING_IGNORES = [ 'dev', 'development', 'prod', 'production' ];
+var DEVELOPMENT_IGNORES = [ 'stage', 'staging', 'prod', 'production' ];
 
 // Real directive processors
 var DIRECTIVE_HANDLERS = {
@@ -427,16 +429,16 @@ getter(DirectiveProcessor.prototype, 'directives', function () {
 
       if (matches && matches[2]) {
 
-        if(process.env.NODE_ENV === 'production' || process.env.NODE_ENVIRONMENT === 'production') {
-          if(PRODUCTION_IGNORES.indexOf(matches[1].toLoweCase()) !== -1) {
-            return;
-          }
-        } else if(process.env.NODE_ENV === 'staging' || process.env.NODE_ENVIRONMENT === 'staging') {
-          if(STAGING_IGNORES.indexOf(matches[1].toLoweCase()) !== -1) {
-            return;
-          }
-        } else { // Default is development
-          if(DEVELOPMENT_IGNORES.indexOf(matches[1].toLoweCase()) !== -1) {
+        if (matches[1]) {
+          var currentEnv = process.env.NODE_ENV || process.env.NODE_ENVIRONMENT || 'development';
+          if (
+            ((currentEnv === 'production')
+              && PRODUCTION_IGNORES.indexOf(matches[1].toLowerCase()) !== -1)
+            || ((currentEnv === 'staging')
+              && STAGING_IGNORES.indexOf(matches[1].toLowerCase()) !== -1)
+            || ((currentEnv === 'development')
+              && DEVELOPMENT_IGNORES.indexOf(matches[1].toLowerCase()) !== -1)
+          ) {
             return;
           }
         }


### PR DESCRIPTION
This PR makes it so that you can put `dev`/`stage`/`prod` between `//` and `=` to make it so that files are only included if NODE_ENV is `dev`, `stage`, or `prod`.

```JavaScript
// Examples:
//
//     //dev= require foo
//     // dev =require foo
//     //dev =require foo
//     //development=require foo
//     //prod=require foo
//     //production=require foo
//     //stage=require foo
//     //staging=require foo
```

This PR needs some tests though.