### PR TITLE
Add support for sass as well as node-sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 tmp/
 doc/
 .idea
+mincer.iml

--- a/lib/mincer/engines/sass_engine.js
+++ b/lib/mincer/engines/sass_engine.js
@@ -1,7 +1,7 @@
 /**
  *  class SassEngine
  *
- *  Engine for the SASS/SCSS compiler. You will need `node-sass` Node module installed
+ *  Engine for the SASS/SCSS compiler. You will need `node-sass` or `sass` Node module installed
  *  in order to use [[Mincer]] with `*.sass` or `*.scss` files:
  *
  *      npm install node-sass
@@ -36,8 +36,17 @@ var logger    = require('../logger');
 // Class constructor
 var SassEngine = module.exports = function SassEngine() {
   Template.apply(this, arguments);
-  sass = sass || Template.libs['node-sass'] || require('node-sass');
-
+  sass = sass || Template.libs['sass'] || Template.libs['node-sass'] || ['sass', 'node-sass'].reduce(function(acc, module) {
+    if (acc) return acc;
+    try {
+      return require(module);
+    } catch(e) {
+      return null;
+    }
+  }, sass);
+  if (!sass) {
+    throw new Error('sass not loaded');
+  }
   // Ensure node sass module has renderSync method
   if (!sass.renderSync) {
     throw new Error('node-sass < v0.5 is not supported.');


### PR DESCRIPTION
We needed to update an old project using mincer and node-sass seems no longer supported. This change allows the newer sass module to be used instead.